### PR TITLE
Update 03_02_solution.sql

### DIFF
--- a/03_02/03_02_solution.sql
+++ b/03_02/03_02_solution.sql
@@ -9,3 +9,10 @@ SET half_hour_starttime =
     INTERVAL '30 minutes' * FLOOR(EXTRACT(MINUTE FROM start_time::timestamp) / 30);
 
 SELECT DATE_TRUNC('hour', start_time::timestamp) FROM trip_data;
+
+-- Alternative Solution Proposed by Selom Heymann (GitHub Username: CipherSR71 | https://www.linkedin.com/in/selom-heymann-1b89431a2)
+UPDATE trip_data
+SET halfHour_starttime = 
+    DATE_BIN('30 minutes', start_time::timestamp, TIMESTAMP '2024-09-17');
+
+SELECT start_time, halfhour_starttime FROM trip_data;


### PR DESCRIPTION
Perhaps instead of using the date_trunc function which requires a little more code, and perhaps a touch more complication to the solution, we could use the date_bin function which automatically "bins" the input timestamp into the specified interval aligned with a specified origin, a function much more in line with binning to visualize data in a histogram.

<!-- This repository *does not* accept pull requests (PRs). All pull requests will be closed. See CONTRIBUTING.md for further details. -->
